### PR TITLE
Refactor/Callout-styles

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,7 @@ permissions:
 
 jobs:
   build:
+    name: Build
     runs-on: ubuntu-latest
     steps:
       - name: Checkout your repository using git
@@ -28,6 +29,7 @@ jobs:
         # package-manager: pnpm@latest # The Node package manager that should be used to install dependencies and build your site. Automatically detected based on your lockfile. (optional)
 
   deploy:
+    name: Deploy
     needs: build
     runs-on: ubuntu-latest
     environment:

--- a/src/components/ArticleComponents.ts
+++ b/src/components/ArticleComponents.ts
@@ -1,0 +1,11 @@
+import Callout from "~/components/Callout/Callout.astro";
+import { Image, Picture } from "astro:assets";
+
+/**
+ * This object is used to import all possible components in Article.
+ */
+export const components = {
+  Callout,
+  Image,
+  Picture,
+};

--- a/src/components/ArticleFooter/ArticleFooter.astro
+++ b/src/components/ArticleFooter/ArticleFooter.astro
@@ -10,7 +10,7 @@ type Props = {
   collection: string;
 };
 
-const { url, currentLocale = DEFAULT_LANG, ...rest } = Astro;
+const { currentLocale = DEFAULT_LANG } = Astro;
 const { slug, collection } = Astro.props;
 
 const t = useTranslations(currentLocale as Language);

--- a/src/components/Callout/Callout.astro
+++ b/src/components/Callout/Callout.astro
@@ -1,6 +1,5 @@
 ---
-import { tokens } from "~/styles/themes.css";
-import { breakpoints } from "~/styles/tokens";
+import { styles } from "./Callout.css";
 
 interface Props {
   variant: "info" | "warning";
@@ -9,71 +8,11 @@ interface Props {
 const { variant } = Astro.props;
 ---
 
-<aside class:list={["callout", variant]}>
-  <div class="badge">
+<aside class:list={[styles.callout, styles.variant[variant]]}>
+  <div class={styles.badge}>
     <svg>
       <use href={`/images/icons.svg#${variant}`}></use>
     </svg>
   </div>
   <slot />
 </aside>
-
-<!--
-TODO: vanilla-extract don't emit styles for the component which used in MDX
-Possible ussie resolved after this ticket https://github.com/vanilla-extract-css/vanilla-extract/issues/1453
- -->
-<style
-  define:vars={{
-    calloutBackgroundColor: tokens.theme.colors.foreground,
-    calloutBlockPadding: tokens.spaces[24],
-    calloutInlinePadding: tokens.spaces[16],
-    calloutInlinePaddingMD: tokens.spaces[32],
-    calloutGap: tokens.spaces[12],
-
-    borderSize: tokens.sizes[4],
-    borderColor: tokens.theme.colors.accent,
-
-    badgeBackgroundColor: tokens.theme.colors.background,
-    iconSize: tokens.sizes[32],
-
-    codeBackgroundColor: tokens.theme.colors.main,
-    codeColor: tokens.theme.colors.accent,
-
-    breakpoints: breakpoints.md,
-  }}
->
-  .callout {
-    position: relative;
-    display: flex;
-    flex-direction: column;
-    gap: var(--calloutGap);
-    padding-block: var(--calloutBlockPadding);
-    padding-inline: var(--calloutInlinePadding);
-    margin-block: var(--calloutBlockPadding);
-    background-color: var(--calloutBackgroundColor);
-    border-inline-start: var(--borderSize) solid var(--borderColor);
-  }
-
-  /* TODO: fix hardcoded breakpoint */
-  @media screen and (min-width: 48rem) {
-    .callout {
-      padding-inline: var(--calloutInlinePaddingMD);
-    }
-  }
-
-  .badge {
-    position: absolute;
-    inset-inline-start: calc((var(--borderSize) / 2) * -1);
-    inset-block-start: calc((var(--borderSize) / 2));
-    transform: translate(-50%, -50%);
-    width: var(--iconSize);
-    height: var(--iconSize);
-    box-shadow: 0 0 0 var(--borderSize) var(--badgeBackgroundColor);
-    background-color: var(--badgeBackgroundColor);
-  }
-
-  svg {
-    width: 100%;
-    height: 100%;
-  }
-</style>

--- a/src/components/Callout/Callout.css.ts
+++ b/src/components/Callout/Callout.css.ts
@@ -1,11 +1,24 @@
 import { style, styleVariants } from "@vanilla-extract/css";
+import { calc } from "@vanilla-extract/css-utils";
 import { tokens } from "~/styles/themes.css";
+import { breakpoints } from "~/styles/tokens";
 
 const callout = style({
+  position: "relative",
+  display: "flex",
+  flexDirection: "column",
+  gap: tokens.spaces[12],
+  paddingBlock: tokens.spaces[24],
+  paddingInline: tokens.spaces[16],
+  marginBlock: tokens.spaces[24],
   backgroundColor: tokens.theme.colors.foreground,
-  paddingInline: tokens.spaces[4],
-  paddingBlock: tokens.spaces[8],
-  border: `5px solid ${tokens.theme.colors.accent}`,
+  borderInlineStart: `${tokens.sizes[4]} solid ${tokens.theme.colors.accent}`,
+
+  "@media": {
+    [`all and (min-width: ${breakpoints.md})`]: {
+      paddingBlock: tokens.sizes[48],
+    },
+  },
 });
 
 const variant = styleVariants({
@@ -18,7 +31,14 @@ const variant = styleVariants({
 });
 
 const badge = style({
-  backgroundColor: "red",
+  position: "absolute",
+  insetInlineStart: calc.negate(tokens.sizes[2]),
+  insetBlockStart: tokens.sizes[2],
+  transform: "translate(-50%, -50%)",
+  width: tokens.sizes[32],
+  height: tokens.sizes[32],
+  boxShadow: `0 0 0 ${tokens.sizes[4]} ${tokens.theme.colors.background}`,
+  backgroundColor: tokens.theme.colors.background,
 });
 
 export const styles = { callout, variant, badge };

--- a/src/content/articles/en/test-post.mdx
+++ b/src/content/articles/en/test-post.mdx
@@ -7,9 +7,6 @@ tags: ["JS", "CSS", "HTML", "React", "Astro"]
 draft: true
 ---
 
-import { Image, Picture } from "astro:assets";
-import Callout from "~/components/Callout/Callout.astro";
-
 import image from "../../../assets/images/in-search-of-the-lost-glyphs/chrome.png";
 
 Here is a sample of some basic Markdown syntax that can be used when writing Markdown content in Astro.

--- a/src/content/articles/ro/in-search-of-the-lost-glyphs.mdx
+++ b/src/content/articles/ro/in-search-of-the-lost-glyphs.mdx
@@ -7,8 +7,6 @@ tags: ["Browser", "CSS", "Typography", "Debugging"]
 ogImage: "/images/in-search-of-the-lost-glyphs/ro.jpg"
 ---
 
-import { Picture, Image } from "astro:assets";
-
 import buttonImageSvg from "~/images/in-search-of-the-lost-glyphs/button.svg";
 import ChromeScreenshot from "~/images/in-search-of-the-lost-glyphs/chrome.png";
 import FFScreenshot from "~/images/in-search-of-the-lost-glyphs/firefox.png";

--- a/src/content/articles/ru/in-search-of-the-lost-glyphs.mdx
+++ b/src/content/articles/ru/in-search-of-the-lost-glyphs.mdx
@@ -7,8 +7,6 @@ tags: ["Browser", "CSS", "Typography", "Debugging"]
 ogImage: "/images/in-search-of-the-lost-glyphs/ru.jpg"
 ---
 
-import { Picture, Image } from "astro:assets";
-
 import buttonImageSvg from "~/images/in-search-of-the-lost-glyphs/button.svg";
 import ChromeScreenshot from "~/images/in-search-of-the-lost-glyphs/chrome.png";
 import FFScreenshot from "~/images/in-search-of-the-lost-glyphs/firefox.png";

--- a/src/content/articles/uk/in-search-of-the-lost-glyphs.mdx
+++ b/src/content/articles/uk/in-search-of-the-lost-glyphs.mdx
@@ -7,8 +7,6 @@ tags: ["Browser", "CSS", "Typography", "Debugging"]
 ogImage: "/images/in-search-of-the-lost-glyphs/uk.jpg"
 ---
 
-import { Picture, Image } from "astro:assets";
-
 import buttonImageSvg from "~/images/in-search-of-the-lost-glyphs/button.svg";
 import ChromeScreenshot from "~/images/in-search-of-the-lost-glyphs/chrome.png";
 import FFScreenshot from "~/images/in-search-of-the-lost-glyphs/firefox.png";

--- a/src/pages/articles/[slug].astro
+++ b/src/pages/articles/[slug].astro
@@ -4,6 +4,7 @@ import { type CollectionEntry, getCollection } from "astro:content";
 import ArticleLayout from "~/layouts/Article/Article.astro";
 import { getPathWithoutLocale } from "~/utils/getPathWithoutLocale";
 import { getCollectionFilter } from "~/utils/getCollectionFilter";
+import { components } from "~/components/ArticleComponents";
 
 export async function getStaticPaths() {
   const isDev = import.meta.env.DEV || false;
@@ -34,5 +35,5 @@ const { Content } = await render();
 ---
 
 <ArticleLayout slug={slug} collection={collection} {...data}>
-  <Content />
+  <Content components={components} />
 </ArticleLayout>

--- a/src/pages/ro/articles/[slug].astro
+++ b/src/pages/ro/articles/[slug].astro
@@ -3,6 +3,7 @@ import { type CollectionEntry, getCollection } from "astro:content";
 import ArticleLayout from "~/layouts/Article/Article.astro";
 import { getPathWithoutLocale } from "~/utils/getPathWithoutLocale";
 import { getCollectionFilter } from "~/utils/getCollectionFilter";
+import { components } from "~/components/ArticleComponents";
 
 export async function getStaticPaths() {
   const isDev = import.meta.env.DEV || false;
@@ -28,5 +29,5 @@ const { Content } = await render();
 ---
 
 <ArticleLayout slug={slug} collection={collection} {...data}>
-  <Content />
+  <Content components={components} />
 </ArticleLayout>

--- a/src/pages/ru/articles/[slug].astro
+++ b/src/pages/ru/articles/[slug].astro
@@ -3,6 +3,7 @@ import { type CollectionEntry, getCollection } from "astro:content";
 import ArticleLayout from "~/layouts/Article/Article.astro";
 import { getPathWithoutLocale } from "~/utils/getPathWithoutLocale";
 import { getCollectionFilter } from "~/utils/getCollectionFilter";
+import { components } from "~/components/ArticleComponents";
 
 export async function getStaticPaths() {
   const isDev = import.meta.env.DEV || false;
@@ -28,5 +29,5 @@ const { Content } = await render();
 ---
 
 <ArticleLayout slug={slug} collection={collection} {...data}>
-  <Content />
+  <Content components={components} />
 </ArticleLayout>

--- a/src/pages/uk/articles/[slug].astro
+++ b/src/pages/uk/articles/[slug].astro
@@ -4,6 +4,7 @@ import { type CollectionEntry, getCollection } from "astro:content";
 import ArticleLayout from "~/layouts/Article/Article.astro";
 import { getPathWithoutLocale } from "~/utils/getPathWithoutLocale";
 import { getCollectionFilter } from "~/utils/getCollectionFilter";
+import { components } from "~/components/ArticleComponents";
 
 export async function getStaticPaths() {
   const isDev = import.meta.env.DEV || false;
@@ -29,5 +30,5 @@ const { Content } = await render();
 ---
 
 <ArticleLayout slug={slug} collection={collection} {...data}>
-  <Content />
+  <Content components={components} />
 </ArticleLayout>


### PR DESCRIPTION
When we use Astro component inside MDX, @vanilla-extract/css doesn't create styles for component (but generate class). Importing components in `<Content>` fix this issue.